### PR TITLE
add server wrap func

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "conversation-api-function",
-  "version": "0.0.13",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/server.js
+++ b/src/server.js
@@ -209,10 +209,14 @@ function checkEnvVars(){
 }
 
 
-function listenServer({ app, config }) {
+function listenServer({ app, config, conversationApiFunctionModule}) {
   const { port } = config;
   return new Promise((resolve) => {
-    return app.listen(port, () => resolve({ config }))
+    const server = app.listen(port, () => resolve({ config }));
+    if (conversationApiFunctionModule.serverWapper && typeof conversationApiFunctionModule.serverWapper == "function") {
+      return conversationApiFunctionModule.serverWapper(server, config);
+    } 
+    return server;
   })
 }
 
@@ -256,7 +260,7 @@ function startServer(conversationApiFunctionModule) {
       const app = createExpressApp(config, conversationApiFunctionModule)
       return { config, app }
     })
-    .then(({ app, config }) => listenServer({ app, config }))
+    .then(({ app, config }) => listenServer({ app, config, conversationApiFunctionModule }))
     .then(({ config }) => {
       const { port } = config;
       logger.info(`config`, config)

--- a/src/server.js
+++ b/src/server.js
@@ -213,8 +213,8 @@ function listenServer({ app, config, conversationApiFunctionModule}) {
   const { port } = config;
   return new Promise((resolve) => {
     const server = app.listen(port, () => resolve({ config }));
-    if (conversationApiFunctionModule.serverWapper && typeof conversationApiFunctionModule.serverWapper == "function") {
-      return conversationApiFunctionModule.serverWapper(server, config);
+    if (conversationApiFunctionModule.serverWrapper && typeof conversationApiFunctionModule.serverWrapper == "function") {
+      return conversationApiFunctionModule.serverWrapper(server, config);
     } 
     return server;
   })


### PR DESCRIPTION
This ia a simple change to `listenServer()` to allow users to wrap the server object from `const server = app.listen(...)`.

Will allow users to export a `serverWrapper(server, config)` function like so
```js
export const serverWrapper = (server, config) => {
    const wsServer = new Server({ noServer: true, path: '/socket' });
    
    wsServer.on('connection', (ws, connectionRequest) => {
        ws.on('message', (message) => {
            console.log(message);
        });
    });

    server.on('upgrade', (request, socket, head) => {
        wsServer.handleUpgrade(request, socket, head, socket => {
            wsServer.emit('connection', socket, request);
        });
    });
};
```

This is particularly useful for adding a websocket server without `express-ws`.

I use this feature in my example here https://github.com/NatoNathan/speech-to-text-websocket-example
